### PR TITLE
Add Protocol attribute to TTSlidingPagesDataSource

### DIFF
--- a/SlidingPages.Bindings/ApiDefinition.cs
+++ b/SlidingPages.Bindings/ApiDefinition.cs
@@ -211,7 +211,7 @@ namespace SlidingPages.Bindings
 		UIImage HeaderImage { get; set; }
 	}
 
-	[Model, BaseType (typeof (NSObject))]
+	[Model, Protocol, BaseType (typeof (NSObject))]
 	public partial interface TTSlidingPagesDataSource {
 
 		[Export ("numberOfPagesForSlidingPagesViewController:")]


### PR DESCRIPTION
Without this you cannot reference and inherit from TTSlidingPagesDataSource in projects using the binding.
